### PR TITLE
setup github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,62 @@
+name: Tests
+
+on:
+  push:
+    paths-ignore: ['*.md', 'CODEOWNERS', 'LICENSE']
+    branches:
+      - 'main'
+      - 'master'
+      - 'release/*'
+  pull_request:
+    paths-ignore: ['*.md', 'CODEOWNERS', 'LICENSE']
+
+jobs:
+  # Runs the pom sorter and code formatter to ensure that the code
+  # is formatted and poms are sorted according to project rules. This
+  # will fail if the formatter makes any changes.
+  check-code-formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-format-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-format-
+            ${{ runner.os }}-maven-
+      - name: Format code
+        run: |
+          mvn -V -B -e clean formatter:format sortpom:sort -Pautoformat
+          git status
+          git diff-index --quiet HEAD || (echo "Error! There are modified files after formatting." && false)
+        env:
+          MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Djava.awt.headless=true"
+
+  # Build the code and run the unit/integration tests.
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-build-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-build-
+            ${{ runner.os }}-maven-format-
+            ${{ runner.os }}-maven-
+      - name: Build and Run Unit Tests
+        run: mvn -V -B -e -Ddist clean verify
+        env:
+          MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Djava.awt.headless=true"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:
     paths-ignore: ['*.md', 'CODEOWNERS', 'LICENSE']
 
 env:
-  JAVA_VERSION: '11'
+  JAVA_VERSION: '8'
   JAVA_DISTRIBUTION: 'zulu'
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
           distribution: ${{env.JAVA_DISTRIBUTION}}
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
           distribution: ${{env.JAVA_DISTRIBUTION}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     paths-ignore: ['*.md', 'CODEOWNERS', 'LICENSE']
 
+env:
+  JAVA_VERSION: '11'
+  JAVA_DISTRIBUTION: 'zulu'
+
 jobs:
   # Runs the pom sorter and code formatter to ensure that the code
   # is formatted and poms are sorted according to project rules. This
@@ -18,12 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
-      - uses: actions/cache@v1
+          distribution: ${{env.JAVA_DISTRIBUTION}}
+          java-version: ${{env.JAVA_VERSION}}
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-format-${{ hashFiles('**/pom.xml') }}
@@ -43,12 +48,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
-      - uses: actions/cache@v1
+          distribution: ${{env.JAVA_DISTRIBUTION}}
+          java-version: ${{env.JAVA_VERSION}}
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-build-${{ hashFiles('**/pom.xml') }}

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </scm>
     <properties>
         <version.avro>1.8.2</version.avro>
-        <version.datawave>3.33.2</version.datawave>
+        <version.datawave>3.40.4</version.datawave>
         <version.guava>25.1-jre</version.guava>
         <version.hadoop>3.3.0</version.hadoop>
         <version.microservice.ingest.common>1.0-SNAPSHOT</version.microservice.ingest.common>


### PR DESCRIPTION
Change Summary
- updated datawave dependency to 3.40.4
- added template for other microservice actions (formatter, build)

This required deploying version 3.40.4 of datawave's ingest-core and ingest-csv