### PR TITLE
Use setup-java action cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,13 +28,7 @@ jobs:
         with:
           distribution: ${{env.JAVA_DISTRIBUTION}}
           java-version: ${{env.JAVA_VERSION}}
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-format-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-format-
-            ${{ runner.os }}-maven-
+          cache: 'maven'
       - name: Format code
         run: |
           mvn -V -B -e clean formatter:format sortpom:sort -Pautoformat
@@ -54,14 +48,7 @@ jobs:
         with:
           distribution: ${{env.JAVA_DISTRIBUTION}}
           java-version: ${{env.JAVA_VERSION}}
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-build-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-build-
-            ${{ runner.os }}-maven-format-
-            ${{ runner.os }}-maven-
+          cache: 'maven'
       - name: Build and Run Unit Tests
         run: mvn -V -B -e -Ddist clean verify
         env:


### PR DESCRIPTION
No reason to use the cache action when we are just caching maven dependencies.