### PR TITLE
29: Start logging to file in container for feeder, bundler and ingest

### DIFF
--- a/bundler/src/main/resources/log4j2.yml
+++ b/bundler/src/main/resources/log4j2.yml
@@ -18,10 +18,27 @@ Configuration:
       follow: true
       PatternLayout:
         pattern: "${LOG_PATTERN}"
+    RollingFile:
+      name: File
+      fileName: ${logDir}/bundler.log
+      filePattern: "${logDir}/bundler.log.%d{yyyy-MM-dd-hh}"
+      Policies:
+        TimeBasedTriggeringPolicy:
+          interval: 1
+          modulate: true
+      DefaultRolloverStrategy:
+        Delete:
+          basePath: ${logDir}
+          IfLastModified:
+            age: 5d
+      PatternLayout:
+        pattern: "%d{yyyy-MM-dd HH:mm:ss.SSS} %5p %c{3} -- %m%n"
 
   Loggers:
     Root:
       level: info
       AppenderRef:
         - ref: Console
+          level: info
+        - ref: File
           level: info

--- a/feeder/src/main/resources/log4j2.yml
+++ b/feeder/src/main/resources/log4j2.yml
@@ -18,10 +18,27 @@ Configuration:
       follow: true
       PatternLayout:
         pattern: "${LOG_PATTERN}"
+    RollingFile:
+      name: File
+      fileName: ${logDir}/feeder.log
+      filePattern: "${logDir}/feeder.log.%d{yyyy-MM-dd-hh}"
+      Policies:
+        TimeBasedTriggeringPolicy:
+          interval: 1
+          modulate: true
+      DefaultRolloverStrategy:
+        Delete:
+          basePath: ${logDir}
+          IfLastModified:
+            age: 5d
+      PatternLayout:
+        pattern: "%d{yyyy-MM-dd HH:mm:ss.SSS} %5p %c{3} -- %m%n"
 
   Loggers:
     Root:
       level: info
       AppenderRef:
         - ref: Console
+          level: info
+        - ref: File
           level: info

--- a/ingest/src/main/resources/log4j2.yml
+++ b/ingest/src/main/resources/log4j2.yml
@@ -18,10 +18,27 @@ Configuration:
       follow: true
       PatternLayout:
         pattern: "${LOG_PATTERN}"
+    RollingFile:
+      name: File
+      fileName: ${logDir}/ingest.log
+      filePattern: "${logDir}/ingest.log.%d{yyyy-MM-dd-hh}"
+      Policies:
+        TimeBasedTriggeringPolicy:
+          interval: 1
+          modulate: true
+      DefaultRolloverStrategy:
+        Delete:
+          basePath: ${logDir}
+          IfLastModified:
+            age: 5d
+      PatternLayout:
+        pattern: "%d{yyyy-MM-dd HH:mm:ss.SSS} %5p %c{3} -- %m%n"
 
   Loggers:
     Root:
       level: info
       AppenderRef:
         - ref: Console
+          level: info
+        - ref: File
           level: info


### PR DESCRIPTION
This is needed for filebeat and ELK integration.
Breaking this out from the larger PR that will follow.