### PR TITLE
29: Add sidecar's for application ELK logging

### DIFF
--- a/bundler/src/main/chart/resources/filebeat.yml
+++ b/bundler/src/main/chart/resources/filebeat.yml
@@ -1,0 +1,15 @@
+filebeat:
+  config:
+    inputs:
+      path: /usr/share/filebeat/conf.d/*
+      reload.enabled: true
+      reload.period: 60s
+
+processors:
+  - drop_fields:
+      fields: [agents.ephemeral_id, agent.id, agent.name, ecs.version, input.type, /^log\..*/]
+
+output:
+  logstash:
+    hosts: '${LOGSTASH_HOST}'
+    loadbalance: true

--- a/bundler/src/main/chart/resources/filebeat/prospector.yml
+++ b/bundler/src/main/chart/resources/filebeat/prospector.yml
@@ -1,0 +1,22 @@
+- type: log
+
+  paths:
+    - "$LOG_LOCATION_REGEX"
+
+  document_type: darkarmy
+  close_inactive: 1h
+  ignore_older: 48h
+  clean_inactive: 96h
+  fields:
+    app.podname: "${POD_NAME}"
+    beats.hostname: "${POD_NAME}"
+    app.hostname: "${LOCAL_HOSTNAME}"
+    service: datawave-ingest
+    logFile: bundlerLog
+    instance: ingest
+    application: bundler-service
+  fields_under_root: true
+  multiline.type: pattern
+  multiline.pattern: "^\x1B\\[2m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}"
+  multiline.negate: true
+  multiline.match: after

--- a/bundler/src/main/chart/resources/logstash.yml
+++ b/bundler/src/main/chart/resources/logstash.yml
@@ -1,0 +1,3 @@
+http.host: "0.0.0.0"
+config.reload.automatic: true
+config.reload.interval: 60s

--- a/bundler/src/main/chart/resources/logstash/filter.conf
+++ b/bundler/src/main/chart/resources/logstash/filter.conf
@@ -1,0 +1,17 @@
+filter {
+    if 'bundlerServiceLog' == [logFile] and 'datawave-ingest' == [service] {
+
+        grok {
+            match => { 'message' => [
+                        '${TIMESTAMP_IOS8601:timestamp} %{LOGLEVEL:logLevel} %{JAVACLASS:class} -- %{GREEDYDATA:message}'
+            ]}
+            overwrite => [ 'message']
+        }
+
+        date {
+            match => [ 'timestamp', "yyy-MM-dd HH:mm:ss,SSS", 'ISO8601']
+            remove_field => [ 'timestamp' ]
+        }
+
+    }
+}

--- a/bundler/src/main/chart/resources/logstash/input.conf
+++ b/bundler/src/main/chart/resources/logstash/input.conf
@@ -1,0 +1,6 @@
+input {
+    beats {
+        port => 5044
+        client_inactivity_timeout => 600
+    }
+}

--- a/bundler/src/main/chart/resources/logstash/output.conf
+++ b/bundler/src/main/chart/resources/logstash/output.conf
@@ -1,0 +1,10 @@
+# Logstash sidecar will always be configured to send to the monitoring namespaces logstash deployment
+output {
+    http {
+        url => 'http://logstash.monitoring:8080'
+        http_method => post
+        retry_non_idempotent => true
+        format => json_batch
+        http_compression => true
+    }
+}

--- a/bundler/src/main/chart/templates/daemonset.yaml
+++ b/bundler/src/main/chart/templates/daemonset.yaml
@@ -91,6 +91,45 @@ spec:
             {{- include "common.volumeMount" $.Values.global.volumes.input | nindent 12 }}
           resources:
             {{- toYaml $.Values.resources | nindent 12 }}
+        {{ if $.Values.filebeat.enabled -}}
+        - name: filebeat
+          image: "{{ $.Values.filebeat.imageRepo }}:{{ $.Values.filebeat.imageTag }}"
+          securityContext:
+            {{- toYaml $.Values.filebeat.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: logs
+              mountPath: {{ $.Values.filebeat.logMountDirectory }}
+            - name: elk-config
+              mountPath: /usr/share/filebeat/filebeat.yml
+              subPath: filebeat.yml
+            - name: filebeat-config
+              mountPath: "/usr/share/filebeat/{{ $.Values.filebeat.pipelineDestDir }}"
+          env:
+            - name: LOCAL_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: LOGSTASH_HOST
+              value: "{{ $.Values.filebeat.logstashHost }}"
+            - name: LOG_LOCATION_REGEX
+              value: {{ printf "%s/%s" $.Values.filebeat.logMountDirectory $.Values.filebeat.logRegex }}
+        {{ if $.Values.logstash.enabled -}}
+        - name: logstash
+          image: "{{ $.Values.logstash.imageRepo }}:{{ $.Values.logstash.imageTag}}"
+          securityContext:
+            {{- toYaml $.Values.logstash.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: elk-config
+              mountPath: /usr/share/logstash/config/logstash.yml
+              subPath: logstash.yml
+            - name: logstash-config
+              mountPath: "/usr/share/logstash/{{ $.Values.logstash.pipelineDestDir }}"
+        {{- end }}
+        {{- end }}
       volumes:
         {{- include "common.volume" $.Values.global.volumes.pki | nindent 8 }}
         {{- include "common.volume" $.Values.global.volumes.hadoop | nindent 8 }}
@@ -108,6 +147,19 @@ spec:
           hostPath:
             path: {{ $.Values.global.volumes.logs.source.path }}
             type: DirectoryOrCreate
+        {{- if $.Values.filebeat.enabled }}
+        - name: elk-config
+          configMap:
+            name: {{ template "bundler.name" $ }}-elk
+        - name: filebeat-config
+          configMap:
+            name: {{ template "bundler.name" $ }}-filebeat
+        {{- if $.Values.logstash.enabled }}
+        - name: logstash-config
+          configMap:
+            name: {{ template "bundler.name" $ }}-logstash
+        {{- end }}
+        {{- end }}
       {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/bundler/src/main/chart/templates/elk-configmap.yaml
+++ b/bundler/src/main/chart/templates/elk-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.filebeat.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "bundler.name" . }}-elk
+data:
+  filebeat.yml: |
+{{ .Files.Get "resources/filebeat.yml" | indent 4 }}
+{{- if .Values.logstash.enabled }}
+  logstash.yml: |
+{{ .Files.Get "resources/logstash.yml" | indent 4 }}
+{{- end }}
+{{- end }}

--- a/bundler/src/main/chart/templates/filebeat-configmap.yaml
+++ b/bundler/src/main/chart/templates/filebeat-configmap.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.filebeat.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "bundler.name" . }}-filebeat
+data:
+{{- (.Files.Glob "resources/filebeat/*").AsConfig | nindent 2 }}
+{{- end }}

--- a/bundler/src/main/chart/templates/logstash-configmap.yaml
+++ b/bundler/src/main/chart/templates/logstash-configmap.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.logstash.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "bundler.name" . }}-logstash
+data:
+{{- (.Files.Glob "resources/logstash/*").AsConfig | nindent 2 }}
+{{- end }}

--- a/bundler/src/main/chart/values.yaml
+++ b/bundler/src/main/chart/values.yaml
@@ -72,3 +72,32 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Configure Filebeat Sidecar
+filebeat:
+  # Enable Sidecar Filebeat container
+  enabled: true
+  imageRepo: docker.elastic.co/beats/filebeat
+  imageTag: 8.7.0
+  # For Logstash Sidecar
+  logstashHost: "localhost:5044"
+  # For logstash Deployment in monitoring namespace
+  #logstashHost: "logstash.monitoring:5044"
+  logMountDirectory: "/logs"
+  logRegex: "ingest*.log"
+  pipelineDestDir: "conf.d"
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 0
+
+logstash:
+  # Enable Sidecar Logstash Container. Requires Filebeat to be enabled.
+  enabled: true
+  imageRepo: docker.elastic.co/logstash/logstash
+  imageTag: 8.7.0
+  pipelineDestDir: "pipeline"
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 0

--- a/feeder/src/main/chart/resources/filebeat.yml
+++ b/feeder/src/main/chart/resources/filebeat.yml
@@ -1,0 +1,15 @@
+filebeat:
+  config:
+    inputs:
+      path: /usr/share/filebeat/conf.d/*
+      reload.enabled: true
+      reload.period: 60s
+
+processors:
+  - drop_fields:
+      fields: [agents.ephemeral_id, agent.id, agent.name, ecs.version, input.type, /^log\..*/]
+
+output:
+  logstash:
+    hosts: '${LOGSTASH_HOST}'
+    loadbalance: true

--- a/feeder/src/main/chart/resources/filebeat/prospector.yml
+++ b/feeder/src/main/chart/resources/filebeat/prospector.yml
@@ -1,0 +1,22 @@
+- type: log
+
+  paths:
+    - "$LOG_LOCATION_REGEX"
+
+  document_type: darkarmy
+  close_inactive: 1h
+  ignore_older: 48h
+  clean_inactive: 96h
+  fields:
+    app.podname: "${POD_NAME}"
+    beats.hostname: "${POD_NAME}"
+    app.hostname: "${LOCAL_HOSTNAME}"
+    service: datawave-ingest
+    logFile: feederLog
+    instance: ingest
+    application: feeder-service
+  fields_under_root: true
+  multiline.type: pattern
+  multiline.pattern: "^\x1B\\[2m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}"
+  multiline.negate: true
+  multiline.match: after

--- a/feeder/src/main/chart/resources/logstash.yml
+++ b/feeder/src/main/chart/resources/logstash.yml
@@ -1,0 +1,3 @@
+http.host: "0.0.0.0"
+config.reload.automatic: true
+config.reload.interval: 60s

--- a/feeder/src/main/chart/resources/logstash/filter.conf
+++ b/feeder/src/main/chart/resources/logstash/filter.conf
@@ -1,0 +1,17 @@
+filter {
+    if 'feederServiceLog' == [logFile] and 'datawave-ingest' == [service] {
+
+        grok {
+            match => { 'message' => [
+                        '${TIMESTAMP_IOS8601:timestamp} %{LOGLEVEL:logLevel} %{JAVACLASS:class} -- %{GREEDYDATA:message}'
+            ]}
+            overwrite => [ 'message']
+        }
+
+        date {
+            match => [ 'timestamp', "yyy-MM-dd HH:mm:ss,SSS", 'ISO8601']
+            remove_field => [ 'timestamp' ]
+        }
+
+    }
+}

--- a/feeder/src/main/chart/resources/logstash/input.conf
+++ b/feeder/src/main/chart/resources/logstash/input.conf
@@ -1,0 +1,6 @@
+input {
+    beats {
+        port => 5044
+        client_inactivity_timeout => 600
+    }
+}

--- a/feeder/src/main/chart/resources/logstash/output.conf
+++ b/feeder/src/main/chart/resources/logstash/output.conf
@@ -1,0 +1,10 @@
+# Logstash sidecar will always be configured to send to the monitoring namespaces logstash deployment
+output {
+    http {
+        url => 'http://logstash.monitoring:8080'
+        http_method => post
+        retry_non_idempotent => true
+        format => json_batch
+        http_compression => true
+    }
+}

--- a/feeder/src/main/chart/templates/deployment.yaml
+++ b/feeder/src/main/chart/templates/deployment.yaml
@@ -90,6 +90,45 @@ spec:
             {{- include "common.volumeMount" $.Values.global.volumes.logs | nindent 12 }}
           resources:
             {{- toYaml $.Values.resources | nindent 12 }}
+        {{ if $.Values.filebeat.enabled -}}
+        - name: filebeat
+          image: "{{ $.Values.filebeat.imageRepo }}:{{ $.Values.filebeat.imageTag }}"
+          securityContext:
+            {{- toYaml $.Values.filebeat.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: logs
+              mountPath: {{ $.Values.filebeat.logMountDirectory }}
+            - name: elk-config
+              mountPath: /usr/share/filebeat/filebeat.yml
+              subPath: filebeat.yml
+            - name: filebeat-config
+              mountPath: "/usr/share/filebeat/{{ $.Values.filebeat.pipelineDestDir }}"
+          env:
+            - name: LOCAL_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: LOGSTASH_HOST
+              value: "{{ $.Values.filebeat.logstashHost }}"
+            - name: LOG_LOCATION_REGEX
+              value: {{ printf "%s/%s" $.Values.filebeat.logMountDirectory $.Values.filebeat.logRegex }}
+        {{ if $.Values.logstash.enabled -}}
+        - name: logstash
+          image: "{{ $.Values.logstash.imageRepo }}:{{ $.Values.logstash.imageTag}}"
+          securityContext:
+            {{- toYaml $.Values.logstash.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: elk-config
+              mountPath: /usr/share/logstash/config/logstash.yml
+              subPath: logstash.yml
+            - name: logstash-config
+              mountPath: "/usr/share/logstash/{{ $.Values.logstash.pipelineDestDir }}"
+        {{- end }}
+        {{- end }}
       volumes:
         {{- include "common.volume" $.Values.global.volumes.pki | nindent 8 }}
         {{- include "common.volume" $.Values.global.volumes.hadoop | nindent 8 }}
@@ -97,6 +136,19 @@ spec:
           hostPath:
             path: {{ $.Values.global.volumes.logs.source.path }}
             type: DirectoryOrCreate
+        {{- if $.Values.filebeat.enabled }}
+        - name: elk-config
+          configMap:
+            name: {{ template "feeder.name" $ }}-elk
+        - name: filebeat-config
+          configMap:
+            name: {{ template "feeder.name" $ }}-filebeat
+        {{- if $.Values.logstash.enabled }}
+        - name: logstash-config
+          configMap:
+            name: {{ template "feeder.name" $ }}-logstash
+        {{- end }}
+        {{- end }}
       {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/feeder/src/main/chart/templates/elk-configmap.yaml
+++ b/feeder/src/main/chart/templates/elk-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.filebeat.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "feeder.name" . }}-elk
+data:
+  filebeat.yml: |
+{{ .Files.Get "resources/filebeat.yml" | indent 4 }}
+{{- if .Values.logstash.enabled }}
+  logstash.yml: |
+{{ .Files.Get "resources/logstash.yml" | indent 4 }}
+{{- end }}
+{{- end }}

--- a/feeder/src/main/chart/templates/filebeat-configmap.yaml
+++ b/feeder/src/main/chart/templates/filebeat-configmap.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.filebeat.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "feeder.name" . }}-filebeat
+data:
+{{- (.Files.Glob "resources/filebeat/*").AsConfig | nindent 2 }}
+{{- end }}

--- a/feeder/src/main/chart/templates/logstash-configmap.yaml
+++ b/feeder/src/main/chart/templates/logstash-configmap.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.logstash.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "feeder.name" . }}-logstash
+data:
+{{- (.Files.Glob "resources/logstash/*").AsConfig | nindent 2 }}
+{{- end }}

--- a/feeder/src/main/chart/values.yaml
+++ b/feeder/src/main/chart/values.yaml
@@ -71,3 +71,32 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Configure Filebeat Sidecar
+filebeat:
+  # Enable Sidecar Filebeat container
+  enabled: true
+  imageRepo: docker.elastic.co/beats/filebeat
+  imageTag: 8.7.0
+  # For Logstash Sidecar
+  logstashHost: "localhost:5044"
+  # For logstash Deployment in monitoring namespace
+  #logstashHost: "logstash.monitoring:5044"
+  logMountDirectory: "/logs"
+  logRegex: "feeder*.log"
+  pipelineDestDir: "conf.d"
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 0
+
+logstash:
+  # Enable Sidecar Logstash Container. Requires Filebeat to be enabled.
+  enabled: true
+  imageRepo: docker.elastic.co/logstash/logstash
+  imageTag: 8.7.0
+  pipelineDestDir: "pipeline"
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 0

--- a/ingest/src/main/chart/resources/filebeat.yml
+++ b/ingest/src/main/chart/resources/filebeat.yml
@@ -1,0 +1,15 @@
+filebeat:
+  config:
+    inputs:
+      path: /usr/share/filebeat/conf.d/*
+      reload.enabled: true
+      reload.period: 60s
+
+processors:
+  - drop_fields:
+      fields: [agents.ephemeral_id, agent.id, agent.name, ecs.version, input.type, /^log\..*/]
+
+output:
+  logstash:
+    hosts: '${LOGSTASH_HOST}'
+    loadbalance: true

--- a/ingest/src/main/chart/resources/filebeat/prospector.yml
+++ b/ingest/src/main/chart/resources/filebeat/prospector.yml
@@ -1,0 +1,22 @@
+- type: log
+
+  paths:
+    - "$LOG_LOCATION_REGEX"
+
+  document_type: darkarmy
+  close_inactive: 1h
+  ignore_older: 48h
+  clean_inactive: 96h
+  fields:
+    app.podname: "${POD_NAME}"
+    beats.hostname: "${POD_NAME}"
+    app.hostname: "${LOCAL_HOSTNAME}"
+    service: datawave-ingest
+    logFile: ingestLog
+    instance: ingest
+    application: ingest-service
+  fields_under_root: true
+  multiline.type: pattern
+  multiline.pattern: "^\x1B\\[2m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}"
+  multiline.negate: true
+  multiline.match: after

--- a/ingest/src/main/chart/resources/logstash.yml
+++ b/ingest/src/main/chart/resources/logstash.yml
@@ -1,0 +1,3 @@
+http.host: "0.0.0.0"
+config.reload.automatic: true
+config.reload.interval: 60s

--- a/ingest/src/main/chart/resources/logstash/filter.conf
+++ b/ingest/src/main/chart/resources/logstash/filter.conf
@@ -1,0 +1,17 @@
+filter {
+    if 'ingestServiceLog' == [logFile] and 'datawave-ingest' == [service] {
+
+        grok {
+            match => { 'message' => [
+                        '${TIMESTAMP_IOS8601:timestamp} %{LOGLEVEL:logLevel} %{JAVACLASS:class} -- %{GREEDYDATA:message}'
+            ]}
+            overwrite => [ 'message']
+        }
+
+        date {
+            match => [ 'timestamp', "yyy-MM-dd HH:mm:ss,SSS", 'ISO8601']
+            remove_field => [ 'timestamp' ]
+        }
+
+    }
+}

--- a/ingest/src/main/chart/resources/logstash/input.conf
+++ b/ingest/src/main/chart/resources/logstash/input.conf
@@ -1,0 +1,6 @@
+input {
+    beats {
+        port => 5044
+        client_inactivity_timeout => 600
+    }
+}

--- a/ingest/src/main/chart/resources/logstash/output.conf
+++ b/ingest/src/main/chart/resources/logstash/output.conf
@@ -1,0 +1,10 @@
+# Logstash sidecar will always be configured to send to the monitoring namespaces logstash deployment
+output {
+    http {
+        url => 'http://logstash.monitoring:8080'
+        http_method => post
+        retry_non_idempotent => true
+        format => json_batch
+        http_compression => true
+    }
+}

--- a/ingest/src/main/chart/templates/deployment.yaml
+++ b/ingest/src/main/chart/templates/deployment.yaml
@@ -163,6 +163,45 @@ spec:
             {{- end }}
           resources:
             {{- toYaml $.Values.resources | nindent 12 }}
+        {{ if $.Values.filebeat.enabled -}}
+        - name: filebeat
+          image: "{{ $.Values.filebeat.imageRepo }}:{{ $.Values.filebeat.imageTag }}"
+          securityContext:
+            {{- toYaml $.Values.filebeat.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: logs
+              mountPath: {{ $.Values.filebeat.logMountDirectory }}
+            - name: elk-config
+              mountPath: /usr/share/filebeat/filebeat.yml
+              subPath: filebeat.yml
+            - name: filebeat-config
+              mountPath: "/usr/share/filebeat/{{ $.Values.filebeat.pipelineDestDir }}"
+          env:
+            - name: LOCAL_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: LOGSTASH_HOST
+              value: "{{ $.Values.filebeat.logstashHost }}"
+            - name: LOG_LOCATION_REGEX
+              value: {{ printf "%s/%s" $.Values.filebeat.logMountDirectory $.Values.filebeat.logRegex }}
+        {{ if $.Values.logstash.enabled -}}
+        - name: logstash
+          image: "{{ $.Values.logstash.imageRepo }}:{{ $.Values.logstash.imageTag}}"
+          securityContext:
+            {{- toYaml $.Values.logstash.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: elk-config
+              mountPath: /usr/share/logstash/config/logstash.yml
+              subPath: logstash.yml
+            - name: logstash-config
+              mountPath: "/usr/share/logstash/{{ $.Values.logstash.pipelineDestDir }}"
+        {{- end }}
+        {{- end }}
       volumes:
         {{- include "common.volume" $.Values.global.volumes.pki | nindent 8 }}
         {{- include "common.volume" $.Values.global.volumes.hadoop | nindent 8 }}
@@ -184,6 +223,19 @@ spec:
           hostPath:
             path: {{ $.Values.global.volumes.logs.source.path }}
             type: DirectoryOrCreate
+        {{- if $.Values.filebeat.enabled }}
+        - name: elk-config
+          configMap:
+            name: {{ template "ingest.name" $ }}-elk
+        - name: filebeat-config
+          configMap:
+            name: {{ template "ingest.name" $ }}-filebeat
+        {{- if $.Values.logstash.enabled }}
+        - name: logstash-config
+          configMap:
+            name: {{ template "ingest.name" $ }}-logstash
+        {{- end }}
+        {{- end }}
       {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/ingest/src/main/chart/templates/elk-configmap.yaml
+++ b/ingest/src/main/chart/templates/elk-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.filebeat.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "ingest.name" . }}-elk
+data:
+  filebeat.yml: |
+{{ .Files.Get "resources/filebeat.yml" | indent 4 }}
+{{- if .Values.logstash.enabled }}
+  logstash.yml: |
+{{ .Files.Get "resources/logstash.yml" | indent 4 }}
+{{- end }}
+{{- end }}

--- a/ingest/src/main/chart/templates/filebeat-configmap.yaml
+++ b/ingest/src/main/chart/templates/filebeat-configmap.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.filebeat.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "ingest.name" . }}-filebeat
+data:
+{{- (.Files.Glob "resources/filebeat/*").AsConfig | nindent 2 }}
+{{- end }}

--- a/ingest/src/main/chart/templates/logstash-configmap.yaml
+++ b/ingest/src/main/chart/templates/logstash-configmap.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.logstash.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "ingest.name" . }}-logstash
+data:
+{{- (.Files.Glob "resources/logstash/*").AsConfig | nindent 2 }}
+{{- end }}

--- a/ingest/src/main/chart/values.yaml
+++ b/ingest/src/main/chart/values.yaml
@@ -130,3 +130,32 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Configure Filebeat Sidecar
+filebeat:
+  # Enable Sidecar Filebeat container
+  enabled: true
+  imageRepo: docker.elastic.co/beats/filebeat
+  imageTag: 8.7.0
+  # For Logstash Sidecar
+  logstashHost: "localhost:5044"
+  # For logstash Deployment in monitoring namespace
+  #logstashHost: "logstash.monitoring:5044"
+  logMountDirectory: "/logs"
+  logRegex: "ingest*.log"
+  pipelineDestDir: "conf.d"
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 0
+
+logstash:
+  # Enable Sidecar Logstash Container. Requires Filebeat to be enabled.
+  enabled: true
+  imageRepo: docker.elastic.co/logstash/logstash
+  imageTag: 8.7.0
+  pipelineDestDir: "pipeline"
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 0


### PR DESCRIPTION
I am open to suggestions to reduce the duplication of config map's. I tried moving them to the common library but they could not have data defined and without that did not see a point in having them in the library just to consume the metadata portion.