### PR TITLE
Limit who can perform tag and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   tag-and-release:
-    if: github.actor != 'cfkoehler' && github.actor != 'FineAndDandy' && github.actor != 'jpdahlke' && github.actor != 'apmoriarty' && github.actor != 'ivakegg'
+    if: contains('${{ vars.RELEASE_USERS }}', github.actor)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           cache: 'maven'
+          token: ${{secrets.PAT}}
       - name: Update Maven Version for release
         run: mvn -V -B -e versions:set -DnewVersion=${{github.event.inputs.release_version}} -DprocessAllModules -DgenerateBackupPoms=false
       - name: Update helm App version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   tag-and-release:
-   if: github.actor != 'cfkoehler' && github.actor != 'FineAndDandy' && github.actor != 'jpdahlke' && github.actor != 'apmoriarty' && github.actor != 'ivakegg'
+    if: github.actor != 'cfkoehler' && github.actor != 'FineAndDandy' && github.actor != 'jpdahlke' && github.actor != 'apmoriarty' && github.actor != 'ivakegg'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ permissions:
   repository-projects: read
 
 jobs:
-  update-version:
+  tag-and-release:
+   if: github.actor != 'cfkoehler' && github.actor != 'FineAndDandy' && github.actor != 'jpdahlke' && github.actor != 'apmoriarty' && github.actor != 'ivakegg'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           cache: 'maven'
-          token: ${{secrets.PAT}}
       - name: Update Maven Version for release
         run: mvn -V -B -e versions:set -DnewVersion=${{github.event.inputs.release_version}} -DprocessAllModules -DgenerateBackupPoms=false
       - name: Update helm App version

--- a/RELEASING.MD
+++ b/RELEASING.MD
@@ -10,7 +10,10 @@ The application follows Semantiv Versioning ([semver.org](semver.org)) for the j
 # GitHub Release Process
 
 ## Triggering a release
-Once all the changes are merged into the master branch and all CI checks are passing the the application is ready for release.
+Once all the changes are merged into the master branch and all CI checks are passing the the application is ready for release. 
+
+**GitHub Release action can only be triggered by users in the `RELEASE_USERS` variable list**
+
 1) Navigate to the Release Action under the github actions tab: [RELEASE ACTION](github.com/NationalSecurityAgency/datawave-ingst-services/actions/workflows/release.yml)
 2) Click the `Run Workflow` button
 3) For Major and Minor releases run workflow from `master` branch


### PR DESCRIPTION
Currently github does not allow a check by the user role and the only way to limit who can perform a dispatch job is by using github username.