### PR TITLE
Allow initContainer value overrides using parent values

### DIFF
--- a/ingest/src/main/chart/templates/deployment.yaml
+++ b/ingest/src/main/chart/templates/deployment.yaml
@@ -26,9 +26,9 @@ spec:
       securityContext:
         {{- toYaml $.Values.podSecurityContext | nindent 8 }}
       initContainers:
-        {{- range $.Values.initContainers }}
-        - name: {{ .name }}
-          image: "{{ default $.Values.image.registry .image.registry | default $.Values.global.registry }}{{ .image.repository }}:{{ .image.tag }}"
+        {{- range $i, $c := $.Values.initContainers }}
+        - name: {{ $c.name }}
+          image: "{{ index $.Values.initContainerOverrides.registry $c.name | default .image.registry | default $.Values.image.registry | default $.Values.global.registry }}{{ index $.Values.initContainerOverrides.repository $c.name | default .image.repository }}:{{ index $.Values.initContainerOverrides.tag $c.name | default .image.tag }}"
           {{- if .securityContext }}
           securityContext:
             {{- toYaml .securityContext | nindent 12 }}


### PR DESCRIPTION
This allows the initContainer list entries to have their values overridden by a parent chart's provided values without redefining the entire initContainer list. The initContainer's name is used to create the index for the list entry so the parent's values.yaml can reference the name knowing it corresponds to the correct index in the initContainer list.